### PR TITLE
Typings improvements

### DIFF
--- a/barcodescanner.d.ts
+++ b/barcodescanner.d.ts
@@ -1,8 +1,6 @@
-declare module "nativescript-barcodescanner" {
-    /**
-     * The options object passed into the scan function.
-     */
-    export interface ScanOptions {
+declare namespace barcodeScanner {
+  namespace ScanOptions {
+    interface Common {
       /**
        * A comma sep. string of barcode types: "QR_CODE,PDF_417"
        * Default: empty, so all types of codes can be scanned.
@@ -10,12 +8,27 @@ declare module "nativescript-barcodescanner" {
       formats?: string;
 
       /**
+       * By default the scanned object is returned in the Promise,
+       * but if you want to scan continuously (until you call 'stop'),
+       * you can provide a callback function that receives the same object
+       * as the Promise would, but every time something is scanned.
+       *
+       * This function doesn't report duplicates in the same scanning session,
+       * you're welcome ;)
+       */
+      continuousScanCallback?: Function;
+    }
+
+    interface IOS extends Common {
+      /**
        * The label of the button used to close the scanner.
        * Default: "Close".
        * iOS only.
        */
       cancelLabel?: string;
+    }
 
+    interface Android extends Common {
       /**
        * The message shown when looking for something to scan.
        * Default: "Place a barcode inside the viewfinder rectangle to scan it."
@@ -31,17 +44,6 @@ declare module "nativescript-barcodescanner" {
       preferFrontCamera?: boolean;
 
       /**
-       * By default the scanned object is returned in the Promise,
-       * but if you want to scan continuously (until you call 'stop'),
-       * you can provide a callback function that receives the same object
-       * as the Promise would, but every time something is scanned.
-       * 
-       * This function doesn't report duplicates in the same scanning session,
-       * you're welcome ;)
-       */
-      continuousScanCallback?: Function;
-
-      /**
        * While scanning for a barcode show a button to flip to the other camera (front or back).
        * Default: false, so no flip button is shown.
        * Android only (on iOS the button is always shown).
@@ -55,13 +57,25 @@ declare module "nativescript-barcodescanner" {
        */
       orientation?: string;
     }
+  }
 
-    export function available(): Promise<boolean>;
-    export function hasCameraPermission(): Promise<boolean>;
-    export function requestCameraPermission(): Promise<boolean>;
-    export function scan(options: ScanOptions): Promise<any>;
+  /**
+   * The options object passed into the scan function.
+   */
+  export interface ScanOptions extends ScanOptions.IOS, ScanOptions.Android {
+  }
+
+  interface BarcodeScanner {
+    available(): Promise<boolean>;
+    hasCameraPermission(): Promise<boolean>;
+    requestCameraPermission(): Promise<boolean>;
+    scan(options: ScanOptions): Promise<any>;
     /**
      * Stop scanning, particularly useful when 'scan' was used with 'continuousScanCallback'
      */
-    export function stop(): Promise<any>;
+    stop(): Promise<any>;
+  }
 }
+
+declare var barcodeScanner: barcodeScanner.BarcodeScanner;
+export = barcodeScanner;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.1",
   "description": "Scan QR/barcodes with a {N} app.",
   "main": "barcodescanner.js",
+  "typings": "barcodescanner.d.ts",
   "nativescript": {
     "platforms": {
       "android": "2.3.0",


### PR DESCRIPTION
First of all, thank you for writing this excellent library and for providing typings for it!  I hope that these changes will help even more people to be able to use this library in their apps.

This PR adds new ways to use the typings you have in this project.  

## Referencing the library

Currently when using this plugin, if you want to get type help, you must reference the .d.ts file using the triple-slash comment before using the `import` statement:

```ts
/// <reference path="../node_modules/nativescript-barcodescanner/barcodescanner.d.ts" />
import barcodescanner = require('nativescript-barcodescanner');
```

This works, but TypeScript now provides [Node module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html#node) which in most cases negates the need for the triple-slash reference.  In this case, however, since the typings are declared as an external/ambient module (i.e. `declare module "nativescript-barcodescanner"`), trying to resolve this module without the reference line causes an error:

> [ts] Exported external package typings file '/Users/jsskeen/git/my-assessments-app/my-assessments/node_modules/nativescript-barcodescanner/barcodescanner.d.ts' is not a module. Please contact the package author to update the package definition.

To fix this, I have removed the ambient module definition so the file itself becomes the declared module.  Now this will work without the reference comment:

```ts
import barcodescanner = require('nativescript-barcodescanner');
// or
import * as barcodescanner from 'nativescript-barcodescanner';
```

Additionally, I have set the `typings` field in the `package.json` to point to the definition file.  Although this isn't strictly required by TypeScript, it does help other tools to find the definition file easier.

## Referencing the type of `barcodescanner` when using dependency injection

The app I am using this library in is a NativeScript Angular app, and although it works to import the barcodescanner and use it directly, it is best practice in Angular to use dependency injection to switch out providers while testing.  This means that I need to make `barcodescanner` be a parameter of a function.  Since the current typings don't expose a type for the barcodescanner itself, the only way to type the function parameter is something like this:

```ts
import * as barcodescanner from 'nativescript-barcodescanner';
...

@Component({ ...})
export class MyComponent implements OnInit {
  constructor(private scanner: typeof barcodescanner) {
  }
  
  ngOnInit() {
    this.scanner.scan({ ... });
  }
}
```

Using the `typeof` keyword whenever I need to refer to the `barcodescanner`'s API is not ideal, and although I could define my own type alias for it, I thought it would be great to expose the API in the definitions themselves.  In order to do this, I use [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to export both the barcodescanner functionality and supporting interfaces as a single export (namespace + value).  This change should be fully backwards-compatible with the current version of the typings.  With these changes, you can use the typings in more ways:

```ts
import * as scanner from 'nativescript-barcodescanner';
import { BarcodeScanner, ScanOptions } from 'nativescript-barcodescanner';
let bs1: scanner.BarcodeScanner;
let bs2: BarcodeScanner;
let opt1: scanner.ScanOptions;
let opt2: ScanOptions;
scanner.scan(opt1);
bs1.scan(opt2);
```

## Platform-specific interfaces

Looking at the scan options, there are several which are exclusive to a single platform.  This means that if I am targeting only iOS, I have to be careful to read the documentation for each option to determine which ones I am able to use.  It would be great if there was some way to only allow for iOS or Android options in a single-platform app, while not messing up cross-platform apps.  This PR makes this possible, again using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).  Now you can do this:

```ts
import * as scanner from 'nativescript-barcodescanner';

// on an iOS only app you can use:
let opts: scanner.ScanOptions.IOS = { ... };
// on an Android only app you can use:
let opts: scanner.ScanOptions.Android = { ... };
// for a cross-platform app you can still use:
let opts: scanner.ScanOptions = { ... };

// regardless of the interface you use, this still works:
scanner.scan(opts);
```

When using platform-specific option interfaces, you will only get autocompletion for options supported on that platform, and specifying an option not valid for that platform will give you an error.

## Footnote

I think it would be great to include instructions on how to wire up this plugin to dependency injection for NativeScript Angular apps.  If you would like help putting this together, I could submit another PR.