### PR TITLE
Use onActivityResult event handler rather than callback method

### DIFF
--- a/barcodescanner.android.ts
+++ b/barcodescanner.android.ts
@@ -191,16 +191,16 @@ export class BarcodeScanner {
 
         if (intent.resolveActivity(com.tns.NativeScriptApplication.getInstance().getPackageManager()) !== null) {
           appModule.android.on('activityResult', (data) => {
-            if (requestCode === SCANNER_REQUEST_CODE) {
+            if (data.requestCode === SCANNER_REQUEST_CODE) {
               if (isContinuous) {
                 if (_onScanReceivedCallback) {
                   self.broadcastManager.unregisterReceiver(_onScanReceivedCallback);
                   _onScanReceivedCallback = undefined;
                 }
               } else {
-                if (resultCode === android.app.Activity.RESULT_OK) {
-                  let format = data.getStringExtra(com.google.zxing.client.android.Intents.Scan.RESULT_FORMAT);
-                  let text = data.getStringExtra(com.google.zxing.client.android.Intents.Scan.RESULT);
+                if (data.resultCode === android.app.Activity.RESULT_OK) {
+                  let format = data.intent.getStringExtra(com.google.zxing.client.android.Intents.Scan.RESULT_FORMAT);
+                  let text = data.intent.getStringExtra(com.google.zxing.client.android.Intents.Scan.RESULT);
                   resolve({
                     format: format,
                     text: text

--- a/barcodescanner.android.ts
+++ b/barcodescanner.android.ts
@@ -190,9 +190,7 @@ export class BarcodeScanner {
         }
 
         if (intent.resolveActivity(com.tns.NativeScriptApplication.getInstance().getPackageManager()) !== null) {
-          let previousResult = appModule.android.onActivityResult;
-          appModule.android.onActivityResult = function (requestCode, resultCode, data) {
-            appModule.android.onActivityResult = previousResult;
+          appModule.android.on('activityResult', (data) => {
             if (requestCode === SCANNER_REQUEST_CODE) {
               if (isContinuous) {
                 if (_onScanReceivedCallback) {
@@ -212,7 +210,7 @@ export class BarcodeScanner {
                 }
               }
             }
-          };
+          });
 
           appModule.android.foregroundActivity.startActivityForResult(intent, SCANNER_REQUEST_CODE);
 


### PR DESCRIPTION
Android specific application callback methods were removed in Nativescript 3.0.
Changelog: https://github.com/NativeScript/NativeScript/blob/v3.0.0/Modules30Changes.md

I believe this fixes #84 and #80.

I also removed the previousResult variable, as I wasn't entirely sure how to handle or what its purpose was.