### PR TITLE
Resolved bug where the scanner was opening after any permission was a…

### DIFF
--- a/barcodescanner.android.ts
+++ b/barcodescanner.android.ts
@@ -39,7 +39,7 @@ export class BarcodeScanner {
     let hasPermission = android.os.Build.VERSION.SDK_INT < 23; // Android M. (6.0)
     if (!hasPermission) {
       hasPermission = android.content.pm.PackageManager.PERMISSION_GRANTED ===
-          android.support.v4.content.ContextCompat.checkSelfPermission(utils.ad.getApplicationContext(), android.Manifest.permission.CAMERA);
+        android.support.v4.content.ContextCompat.checkSelfPermission(utils.ad.getApplicationContext(), android.Manifest.permission.CAMERA);
     }
     return hasPermission;
   };
@@ -48,9 +48,9 @@ export class BarcodeScanner {
     this.onPermissionGranted = onPermissionGranted;
     this.onPermissionRejected = reject;
     android.support.v4.app.ActivityCompat.requestPermissions(
-        appModule.android.foregroundActivity,
-        [android.Manifest.permission.CAMERA],
-        234 // irrelevant since we simply invoke onPermissionGranted
+      appModule.android.foregroundActivity,
+      [android.Manifest.permission.CAMERA],
+      234 // irrelevant since we simply invoke onPermissionGranted
     );
   };
 
@@ -192,6 +192,7 @@ export class BarcodeScanner {
         if (intent.resolveActivity(com.tns.NativeScriptApplication.getInstance().getPackageManager()) !== null) {
           let previousResult = appModule.android.onActivityResult;
           appModule.android.onActivityResult = function (requestCode, resultCode, data) {
+            self.onPermissionGranted = null;
             appModule.android.onActivityResult = previousResult;
             if (requestCode === SCANNER_REQUEST_CODE) {
               if (isContinuous) {


### PR DESCRIPTION
The plugin is registering a callback that is called after any permission where granted.

The barcode scanner works ok, but when i went to another screen where the user was asket for GPS permission, the barcode-scanner callback was beign triggeerd again and it was opening the screen to the user.

In this PR, i'am just setting the self.onPermissionGranted to null after the barcode-scanner intent returns something.

ty =)
