### PR TITLE
Help users troubleshoot the zxing of undefined error via README

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,9 @@ providers: [
   { provide: BarcodeScanner, useFactory: (createBarcodeScanner) }
 ]
 ```
+
+## Troubleshooting
+If you get the error `TypeError: Cannot read property 'zxing' of undefined` on android, try the following steps:
+1. Delete the app from your device
+2. Remove the folder `platforms/android`. This triggers a complete rebuild
+3. run `tns run android`


### PR DESCRIPTION
I found different issues with the zxing of undefined bug. Thought i just need to stop my app and run `tns run android` again. Found this issue https://github.com/EddyVerbruggen/nativescript-barcodescanner/issues/64 which helped me. Removing the platform was the way to go.

Long story short: Think this entry in the README.md will help people like me ;)