### PR TITLE
Fix return type of requestCameraPermissions for IOS

### DIFF
--- a/src/barcodescanner.ios.ts
+++ b/src/barcodescanner.ios.ts
@@ -156,8 +156,7 @@ export class BarcodeScanner {
   public requestCameraPermission(): Promise<boolean> {
     return new Promise((resolve) => {
       // this will trigger the prompt on iOS 10+
-      QRCodeReader.isAvailable();
-      resolve();
+      resolve(QRCodeReader.isAvailable());
     });
   }
 


### PR DESCRIPTION
Fixed an issue where the requestCameraPermissions did not return a boolean in the promise.

The Android version still needs to be fixed.