### PR TITLE
fixed: Unresolved promise in continuousScanCallback freezes UI

### DIFF
--- a/src/barcodescanner.android.ts
+++ b/src/barcodescanner.android.ts
@@ -213,7 +213,10 @@ export class BarcodeScanner {
                   reject("Scan aborted");
                 }
               }
-              arg.closeCallback && arg.closeCallback();
+              if (arg.closeCallback) {
+                arg.closeCallback();
+                resolve(null);
+              }
               Application.android.off('activityResult', onScanResult);
             }
           };

--- a/src/barcodescanner.android.ts
+++ b/src/barcodescanner.android.ts
@@ -200,6 +200,7 @@ export class BarcodeScanner {
                   this.broadcastManager.unregisterReceiver(_onScanReceivedCallback);
                   _onScanReceivedCallback = undefined;
                 }
+                resolve(null);
               } else {
                 if (data.resultCode === android.app.Activity.RESULT_OK) {
                   const format = data.intent.getStringExtra(com.google.zxing.client.android.Intents.Scan.RESULT_FORMAT);
@@ -213,10 +214,7 @@ export class BarcodeScanner {
                   reject("Scan aborted");
                 }
               }
-              if (arg.closeCallback) {
-                arg.closeCallback();
-                resolve(null);
-              }
+              arg.closeCallback && arg.closeCallback();
               Application.android.off('activityResult', onScanResult);
             }
           };


### PR DESCRIPTION
When using continuousScanCallback, after closing the scanner, any bound variable that is updated during multiple-capture will not be updated until page navigates or a button is pressed.